### PR TITLE
Extend field attribute options

### DIFF
--- a/Attributes/KeystoneFieldAttribute.cs
+++ b/Attributes/KeystoneFieldAttribute.cs
@@ -10,6 +10,13 @@ namespace Keystone4Net.Attributes
         public bool IsRequired { get; init; }
         public KeystoneIndex Index { get; init; }
         public string? DisplayMode { get; init; }
+        public object? DefaultValue { get; init; }
+        public bool DbIsNullable { get; init; }
+        public string? DbMap { get; init; }
+        public string? DbNativeType { get; init; }
+        public bool GraphqlReadIsNonNull { get; init; }
+        public bool GraphqlCreateIsNonNull { get; init; }
+        public bool GraphqlUpdateIsNonNull { get; init; }
 
         public KeystoneFieldAttribute(KeystoneFieldType fieldType)
         {

--- a/Keystone4Net.csproj
+++ b/Keystone4Net.csproj
@@ -2,6 +2,9 @@
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
+        <RuntimeFrameworkVersion>9.0.3</RuntimeFrameworkVersion>
+        <AspNetCoreTargetingPackVersion>9.0.3</AspNetCoreTargetingPackVersion>
+        <TargetLatestRuntimePatch>false</TargetLatestRuntimePatch>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Authors>Denis Kudelin</Authors>


### PR DESCRIPTION
## Summary
- add options like default value and db mapping to `KeystoneFieldAttribute`
- use new options in code generation
- specify runtime pack versions in project file

## Testing
- `dotnet restore Keystone4Net.sln --source ./packages` *(fails: Unable to find package Microsoft.NETCore.App.Ref 9.0.4)*