### PR TITLE
Refactor generator and extend field options

### DIFF
--- a/Attributes/KeystoneFieldAttribute.cs
+++ b/Attributes/KeystoneFieldAttribute.cs
@@ -9,7 +9,27 @@ namespace Keystone4Net.Attributes
         public KeystoneFieldType FieldType { get; }
         public bool IsRequired { get; init; }
         public KeystoneIndex Index { get; init; }
-        public string? DisplayMode { get; init; }
+        public KeystoneFieldDisplayMode? DisplayMode { get; init; }
+        public bool IsFilterable { get; init; } = true;
+        public bool IsOrderable { get; init; } = true;
+        public string? Label { get; init; }
+        public object? DefaultValue { get; init; }
+        public bool DbIsNullable { get; init; }
+        public string? DbMap { get; init; }
+        public string? DbNativeType { get; init; }
+        public bool DbUpdatedAt { get; init; }
+        public int? MinLength { get; init; }
+        public int? MaxLength { get; init; }
+        public string? MatchRegex { get; init; }
+        public string? MatchExplanation { get; init; }
+        public object? Min { get; init; }
+        public object? Max { get; init; }
+        public bool GraphqlReadIsNonNull { get; init; }
+        public bool GraphqlCreateIsNonNull { get; init; }
+        public bool GraphqlUpdateIsNonNull { get; init; }
+        public bool GraphqlOmitRead { get; init; }
+        public bool GraphqlOmitCreate { get; init; }
+        public bool GraphqlOmitUpdate { get; init; }
 
         public KeystoneFieldAttribute(KeystoneFieldType fieldType)
         {

--- a/Enums/KeystoneFieldDisplayMode.cs
+++ b/Enums/KeystoneFieldDisplayMode.cs
@@ -1,0 +1,13 @@
+namespace Keystone4Net.Enums
+{
+    public enum KeystoneFieldDisplayMode
+    {
+        Input,
+        Textarea,
+        Select,
+        SegmentedControl,
+        Radio,
+        Cards,
+        Count
+    }
+}

--- a/Keystone4Net.csproj
+++ b/Keystone4Net.csproj
@@ -1,7 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
+        <RuntimeFrameworkVersion>10.0.0-preview.4.24255.5</RuntimeFrameworkVersion>
+        <AspNetCoreTargetingPackVersion>10.0.0-preview.4.24267.6</AspNetCoreTargetingPackVersion>
+        <TargetLatestRuntimePatch>false</TargetLatestRuntimePatch>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Authors>Denis Kudelin</Authors>


### PR DESCRIPTION
## Summary
- use .NET 10 preview
- add `KeystoneFieldDisplayMode` enum
- expand `KeystoneFieldAttribute` with filter/order, label and validation settings
- refactor generator with helper methods

## Testing
- `dotnet restore Keystone4Net.sln --source ./packages --verbosity minimal`
- `dotnet build Keystone4Net.sln --no-restore --verbosity minimal`
