### PR TITLE
Enhance generator readability

### DIFF
--- a/Attributes/KeystoneFieldAttribute.cs
+++ b/Attributes/KeystoneFieldAttribute.cs
@@ -9,7 +9,14 @@ namespace Keystone4Net.Attributes
         public KeystoneFieldType FieldType { get; }
         public bool IsRequired { get; init; }
         public KeystoneIndex Index { get; init; }
-        public string? DisplayMode { get; init; }
+        public KeystoneDisplayMode? DisplayMode { get; init; }
+        public object? DefaultValue { get; init; }
+        public bool DbIsNullable { get; init; }
+        public string? DbMap { get; init; }
+        public string? DbNativeType { get; init; }
+        public bool GraphqlReadIsNonNull { get; init; }
+        public bool GraphqlCreateIsNonNull { get; init; }
+        public bool GraphqlUpdateIsNonNull { get; init; }
 
         public KeystoneFieldAttribute(KeystoneFieldType fieldType)
         {

--- a/Enums/KeystoneDisplayMode.cs
+++ b/Enums/KeystoneDisplayMode.cs
@@ -1,0 +1,11 @@
+namespace Keystone4Net.Enums
+{
+    public enum KeystoneDisplayMode
+    {
+        Input,
+        Textarea,
+        Select,
+        Cards,
+        Count
+    }
+}

--- a/Extensions/EnumExtensions.cs
+++ b/Extensions/EnumExtensions.cs
@@ -1,0 +1,19 @@
+using Keystone4Net.Enums;
+
+namespace Keystone4Net.Extensions
+{
+    public static class EnumExtensions
+    {
+        public static string ToJs(this KeystoneFieldType type)
+        {
+            var name = type.ToString();
+            return char.ToLowerInvariant(name[0]) + name.Substring(1);
+        }
+
+        public static string ToJs(this KeystoneDisplayMode mode)
+        {
+            var name = mode.ToString();
+            return char.ToLowerInvariant(name[0]) + name.Substring(1);
+        }
+    }
+}

--- a/Keystone4Net.csproj
+++ b/Keystone4Net.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Authors>Denis Kudelin</Authors>


### PR DESCRIPTION
## Summary
- add `KeystoneDisplayMode` enum
- use extension methods to output enum values in JS
- gather field options through `BuildFieldOptions`
- simplify config generation with raw strings
- target .NET 10.0

## Testing
- `dotnet restore Keystone4Net.sln --source ./packages`
- `dotnet build Keystone4Net.sln --no-restore --verbosity minimal`