### PR TITLE
Add admin UI options and field modes

### DIFF
--- a/Attributes/KeystoneFieldAttribute.cs
+++ b/Attributes/KeystoneFieldAttribute.cs
@@ -11,7 +11,7 @@ public sealed class KeystoneFieldAttribute(KeystoneFieldType fieldType) : Keysto
 
     public object? Options { get; init; }
     
-    public ListUiOptions Ui { get; init; }
+    public FieldUiOptions? Ui { get; init; }
 
     internal override object Build()
     {

--- a/Attributes/KeystoneListAttribute.cs
+++ b/Attributes/KeystoneListAttribute.cs
@@ -13,4 +13,6 @@ public sealed class KeystoneListAttribute : KeystoneBaseAttribute
     public string? Path { get; init; }
 
     public KeystoneListAccess Access { get; init; } = KeystoneListAccess.AllowAll;
+
+    public ListUiOptions? Ui { get; init; }
 }

--- a/CodeGeneration/Options.cs
+++ b/CodeGeneration/Options.cs
@@ -2,18 +2,85 @@ using Keystone4Net.Enums;
 
 namespace Keystone4Net.CodeGeneration;
 
+public sealed class ListInitialSortOptions
+{
+    public string Field { get; init; } = string.Empty;
+    public KeystoneSortDirection Direction { get; init; }
+}
+
 public sealed class ListViewOptions
 {
+    public KeystoneFieldMode? DefaultFieldMode { get; init; }
     public string[] InitialColumns { get; init; } = [];
+    public ListInitialSortOptions? InitialSort { get; init; }
+    public int? PageSize { get; init; }
 }
 
 public sealed record JsFunction(string Body, params string[] Args);
 internal sealed record JsFunctionCall(KeystoneImportObjects Object, string Name, params object?[] Args);
 
+public sealed class ViewOptions
+{
+    public KeystoneFieldMode DefaultFieldMode { get; init; }
+}
+
 public sealed class ListUiOptions
 {
     public string? Label { get; init; }
+    public string? LabelField { get; init; }
+    public string[]? SearchFields { get; init; }
+    public string? Description { get; init; }
+    public bool HideNavigation { get; init; }
     public bool HideCreate { get; init; }
     public bool HideDelete { get; init; }
+    public ViewOptions? CreateView { get; init; }
+    public ViewOptions? ItemView { get; init; }
     public ListViewOptions? ListView { get; init; }
+    public string? Singular { get; init; }
+    public string? Plural { get; init; }
+    public string? Path { get; init; }
+}
+
+public sealed class TextFieldOptions
+{
+    public TextValidationOptions? Validation { get; init; }
+    public TextUiOptions? Ui { get; init; }
+    public KeystoneIndex IsIndexed { get; init; }
+}
+
+public sealed class FieldUiOptions
+{
+    public string? Views { get; init; }
+    public ViewOptions? CreateView { get; init; }
+    public ItemViewOptions? ItemView { get; init; }
+    public ViewOptions? ListView { get; init; }
+}
+
+public sealed class ItemViewOptions : ViewOptions
+{
+    public KeystoneFieldPosition FieldPosition { get; init; }
+}
+
+public sealed class TextValidationOptions
+{
+    public bool IsRequired { get; init; }
+    public TextLengthOptions? Length { get; init; }
+    public TextMatchOptions? Match { get; init; }
+}
+
+public sealed class TextLengthOptions
+{
+    public int Min { get; init; }
+    public int? Max { get; init; }
+}
+
+public sealed class TextMatchOptions
+{
+    public string Regex { get; init; } = string.Empty;
+    public string? Explanation { get; init; }
+}
+
+public sealed class TextUiOptions : FieldUiOptions
+{
+    public KeystoneDisplayMode DisplayMode { get; init; }
 }

--- a/Enums/KeystoneFieldMode.cs
+++ b/Enums/KeystoneFieldMode.cs
@@ -1,0 +1,9 @@
+namespace Keystone4Net.Enums;
+
+public enum KeystoneFieldMode
+{
+    Edit,
+    Read,
+    Hidden
+}
+

--- a/Enums/KeystoneFieldPosition.cs
+++ b/Enums/KeystoneFieldPosition.cs
@@ -1,0 +1,8 @@
+namespace Keystone4Net.Enums;
+
+public enum KeystoneFieldPosition
+{
+    Form,
+    Sidebar
+}
+

--- a/Enums/KeystoneSortDirection.cs
+++ b/Enums/KeystoneSortDirection.cs
@@ -1,0 +1,8 @@
+namespace Keystone4Net.Enums;
+
+public enum KeystoneSortDirection
+{
+    Asc,
+    Desc
+}
+

--- a/Keystone.cs
+++ b/Keystone.cs
@@ -12,10 +12,11 @@ public class Keystone(DbContext db)
     {
         var json = new KeystoneOptionsSerializer().Serialize(db);
         var sb = new StringBuilder();
-        foreach (var value in  Enum.GetValues<KeystoneImportObjects>())
+        foreach (var value in Enum.GetValues<KeystoneImportObjects>())
         {
-            var importFrom = value == KeystoneImportObjects.Core ? "" : "/" + value;
-            sb.Append($"import * as {value} from '@keystone-6/core{importFrom}';");
+            var name = Utils.ToCamelCase(value.ToString());
+            var importFrom = value == KeystoneImportObjects.Core ? "" : "/" + name;
+            sb.Append($"import * as {name} from '@keystone-6/core{importFrom}';");
         }
         
         sb.AppendLine();


### PR DESCRIPTION
## Summary
- implement more admin UI options
- add new enums for field mode, position and sort direction
- support field UI options
- allow indexing configuration for text fields

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683b49117d6c832db157e540b15fc69a