### PR TITLE
Add keystone settings API with example

### DIFF
--- a/Example/Entities.cs
+++ b/Example/Entities.cs
@@ -1,0 +1,15 @@
+namespace Example.Entities;
+
+public class General
+{
+    public int Id { get; set; }
+    public string Endpoint { get; set; } = string.Empty;
+}
+
+public class Model
+{
+    public int Id { get; set; }
+    public string ModelName { get; set; } = string.Empty;
+    public bool OverridePrompt { get; set; }
+    public string PromptText { get; set; } = string.Empty;
+}

--- a/Example/KeystoneBuilder.cs
+++ b/Example/KeystoneBuilder.cs
@@ -1,0 +1,81 @@
+using Example.Entities;
+using Keystone4Net.CodeGeneration;
+using Keystone4Net.Enums;
+using Keystone4Net.Settings;
+
+namespace Example;
+
+public static class KeystoneBuilder
+{
+    public static Keystone Build()
+    {
+        var keystone = new Keystone
+        {
+            DbProvider = KeystoneDbProvider.Sqlite,
+            DbUrl = "file:../database/db.sqlite",
+            Session = new JsFunctionCall(
+                KeystoneImportObjects.Session,
+                "statelessSessions",
+                new SessionSettings
+                {
+                    Secret = "uBqhTZVmYgUjcmG@GtVm9K#LCC7u?4:J",
+                    MaxAge = 60 * 60 * 24 * 3650
+                }
+            ),
+            Ui = new UiSettings
+            {
+                IsDisabled = false,
+                IsAccessAllowed = new JsFunction("true")
+            }
+        };
+
+        var general = new KeystoneList<General>("General")
+        {
+            Access = KeystoneListAccess.AllowAll,
+            Ui = new ListUiOptions
+            {
+                HideCreate = true,
+                HideDelete = true,
+                Label = "General settings"
+            }
+        };
+        general.AddField(
+            "endpoint",
+            KeystoneFieldType.Text,
+            new TextFieldOptions
+            {
+                Validation = new TextValidationOptions { IsRequired = true }
+            }
+        );
+
+        var model = new KeystoneList<Model>("Model")
+        {
+            Access = KeystoneListAccess.AllowAll,
+            Ui = new ListUiOptions
+            {
+                ListView = new ListViewOptions { InitialColumns = ["modelName"] }
+            }
+        };
+        model.AddField(
+            "modelName",
+            KeystoneFieldType.Text,
+            new TextFieldOptions
+            {
+                Validation = new TextValidationOptions { IsRequired = true }
+            }
+        );
+        model.AddField("overridePrompt", KeystoneFieldType.Checkbox);
+        model.AddField(
+            "promptText",
+            KeystoneFieldType.Text,
+            new TextFieldOptions
+            {
+                Ui = new TextUiOptions { DisplayMode = KeystoneDisplayMode.Textarea }
+            }
+        );
+
+        keystone.AddList(general);
+        keystone.AddList(model);
+        return keystone;
+    }
+}

--- a/Settings/Keystone.cs
+++ b/Settings/Keystone.cs
@@ -1,6 +1,31 @@
+using Keystone4Net.CodeGeneration;
+using Keystone4Net.Enums;
+
 namespace Keystone4Net.Settings;
 
 public sealed class Keystone
 {
-    public List<KeystoneList> List { get; } = [];
+    public KeystoneDbProvider DbProvider { get; set; }
+    public string DbUrl { get; set; } = string.Empty;
+    public JsFunctionCall? Session { get; set; }
+    public UiSettings? Ui { get; set; }
+    public List<KeystoneList> Lists { get; } = [];
+
+    public Keystone AddList(KeystoneList list)
+    {
+        Lists.Add(list);
+        return this;
+    }
+}
+
+public sealed class UiSettings
+{
+    public bool IsDisabled { get; set; }
+    public JsFunction? IsAccessAllowed { get; set; }
+}
+
+public sealed class SessionSettings
+{
+    public string Secret { get; set; } = string.Empty;
+    public int MaxAge { get; set; }
 }

--- a/Settings/KeystoneList.cs
+++ b/Settings/KeystoneList.cs
@@ -1,11 +1,35 @@
+using Keystone4Net.CodeGeneration;
+using Keystone4Net.Enums;
+
 namespace Keystone4Net.Settings;
 
 public abstract class KeystoneList
 {
-    
+    private readonly Dictionary<string, KeystoneField> fields = new();
+
+    protected KeystoneList(string name, Type entityType)
+    {
+        Name = name;
+        EntityType = entityType;
+    }
+
+    public string Name { get; }
+    public Type EntityType { get; }
+    public KeystoneListAccess Access { get; set; }
+    public ListUiOptions? Ui { get; set; }
+    public IReadOnlyDictionary<string, KeystoneField> Fields => fields;
+
+    public void AddField(string name, KeystoneFieldType type, object? options = null)
+    {
+        fields[name] = new KeystoneField(name, type, options);
+    }
 }
 
 public sealed class KeystoneList<T> : KeystoneList
 {
-
+    public KeystoneList(string name) : base(name, typeof(T))
+    {
+    }
 }
+
+public sealed record KeystoneField(string Name, KeystoneFieldType Type, object? Options);


### PR DESCRIPTION
## Summary
- create settings classes for Keystone configuration
- include record for field definition
- provide sample configuration using `General` and `Model` entities

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b6d615388832db1b0024a70d623c4