### PR TITLE
Add typed field access and base options

### DIFF
--- a/Entities/FieldOptions.cs
+++ b/Entities/FieldOptions.cs
@@ -1,0 +1,148 @@
+namespace Keystone4Net.Entities;
+
+public class KeystoneCheckboxFieldOptions : KeystoneFieldOptions
+{
+    public bool? DefaultValue { get; set; }
+    public KeystoneCheckboxDbOptions? Db { get; set; }
+}
+
+public class KeystoneIntegerFieldOptions : KeystoneFieldOptions
+{
+    public int? DefaultValue { get; set; }
+    public KeystoneIntegerDbOptions? Db { get; set; }
+    public KeystoneIntegerValidationOptions? Validation { get; set; }
+}
+
+public class KeystoneBigIntFieldOptions : KeystoneFieldOptions
+{
+    public long? DefaultValue { get; set; }
+    public KeystoneBigIntDbOptions? Db { get; set; }
+    public KeystoneBigIntValidationOptions? Validation { get; set; }
+}
+
+public class KeystoneFloatFieldOptions : KeystoneFieldOptions
+{
+    public double? DefaultValue { get; set; }
+    public KeystoneFloatDbOptions? Db { get; set; }
+    public KeystoneFloatValidationOptions? Validation { get; set; }
+}
+
+public class KeystoneDecimalFieldOptions : KeystoneFieldOptions
+{
+    public decimal? DefaultValue { get; set; }
+    public KeystoneDecimalDbOptions? Db { get; set; }
+    public KeystoneDecimalValidationOptions? Validation { get; set; }
+}
+
+public class KeystonePasswordFieldOptions : KeystoneFieldOptions
+{
+    public string? DefaultValue { get; set; }
+    public KeystonePasswordDbOptions? Db { get; set; }
+    public KeystonePasswordValidationOptions? Validation { get; set; }
+}
+
+public class KeystoneTimestampFieldOptions : KeystoneFieldOptions
+{
+    public DateTime? DefaultValue { get; set; }
+    public KeystoneTimestampDbOptions? Db { get; set; }
+    public KeystoneTimestampValidationOptions? Validation { get; set; }
+}
+
+public class KeystoneCalendarDayFieldOptions : KeystoneFieldOptions
+{
+    public string? DefaultValue { get; set; }
+    public KeystoneCalendarDayDbOptions? Db { get; set; }
+    public KeystoneCalendarDayValidationOptions? Validation { get; set; }
+}
+
+public class KeystoneJsonFieldOptions : KeystoneFieldOptions
+{
+    public object? DefaultValue { get; set; }
+    public KeystoneJsonDbOptions? Db { get; set; }
+}
+
+public class KeystoneBytesFieldOptions : KeystoneFieldOptions
+{
+    public byte[]? DefaultValue { get; set; }
+    public KeystoneBytesDbOptions? Db { get; set; }
+}
+
+public class KeystoneMultiselectFieldOptions : KeystoneFieldOptions
+{
+    public string[]? DefaultValue { get; set; }
+    public object[]? Options { get; set; }
+    public KeystoneMultiselectDbOptions? Db { get; set; }
+}
+
+public class KeystoneSelectFieldOptions : KeystoneFieldOptions
+{
+    public object? DefaultValue { get; set; }
+    public object[]? Options { get; set; }
+    public KeystoneSelectDbOptions? Db { get; set; }
+    public KeystoneSelectValidationOptions? Validation { get; set; }
+}
+
+public class KeystoneDocumentFieldOptions : KeystoneFieldOptions
+{
+    public KeystoneDocumentDbOptions? Db { get; set; }
+}
+
+public class KeystoneRelationshipFieldOptions : KeystoneFieldOptions
+{
+    public bool? Many { get; set; }
+    public string Ref { get; set; } = string.Empty;
+    public KeystoneRelationshipDbOptions? Db { get; set; }
+    public KeystoneRelationshipUiOptions? Ui { get; set; }
+}
+
+public class KeystoneVirtualFieldOptions : KeystoneFieldOptions
+{
+}
+
+public class KeystoneFileFieldOptions : KeystoneFieldOptions
+{
+    public KeystoneFileDbOptions? Db { get; set; }
+    public object? Storage { get; set; }
+    public KeystoneJsFunction? TransformName { get; set; }
+}
+
+public class KeystoneImageFieldOptions : KeystoneFieldOptions
+{
+    public KeystoneImageDbOptions? Db { get; set; }
+    public object? Storage { get; set; }
+    public KeystoneJsFunction? TransformName { get; set; }
+}
+
+public class KeystoneCloudinaryImageFieldOptions : KeystoneFieldOptions
+{
+    public KeystoneCloudinaryDbOptions? Db { get; set; }
+    public KeystoneCloudinaryCredentials Cloudinary { get; set; } = new();
+}
+
+public class KeystoneCheckboxDbOptions { }
+public class KeystoneIntegerDbOptions { public bool? IsNullable { get; set; } public string? Map { get; set; } }
+public class KeystoneIntegerValidationOptions { public bool IsRequired { get; set; } public int? Min { get; set; } public int? Max { get; set; } }
+public class KeystoneBigIntDbOptions { public bool? IsNullable { get; set; } public string? Map { get; set; } }
+public class KeystoneBigIntValidationOptions { public bool IsRequired { get; set; } public long? Min { get; set; } public long? Max { get; set; } }
+public class KeystoneFloatDbOptions { public bool? IsNullable { get; set; } public string? Map { get; set; } }
+public class KeystoneFloatValidationOptions { public bool IsRequired { get; set; } public double? Min { get; set; } public double? Max { get; set; } }
+public class KeystoneDecimalDbOptions { public bool? IsNullable { get; set; } public string? Map { get; set; } }
+public class KeystoneDecimalValidationOptions { public bool IsRequired { get; set; } public decimal? Min { get; set; } public decimal? Max { get; set; } }
+public class KeystonePasswordDbOptions { public bool? IsNullable { get; set; } public string? Map { get; set; } }
+public class KeystonePasswordValidationOptions { public bool IsRequired { get; set; } public bool RejectCommon { get; set; } public KeystoneTextMatchOptions? Match { get; set; } public KeystoneTextLengthOptions? Length { get; set; } }
+public class KeystoneTimestampDbOptions { public bool? IsNullable { get; set; } public string? Map { get; set; } }
+public class KeystoneTimestampValidationOptions { public bool IsRequired { get; set; } }
+public class KeystoneCalendarDayDbOptions { public bool? IsNullable { get; set; } }
+public class KeystoneCalendarDayValidationOptions { public bool IsRequired { get; set; } }
+public class KeystoneJsonDbOptions { public string? Map { get; set; } }
+public class KeystoneBytesDbOptions { public bool? IsNullable { get; set; } public string? Map { get; set; } }
+public class KeystoneMultiselectDbOptions { public bool? IsNullable { get; set; } public string? Map { get; set; } }
+public class KeystoneSelectDbOptions { public bool? IsNullable { get; set; } public string? Map { get; set; } }
+public class KeystoneSelectValidationOptions { public bool IsRequired { get; set; } }
+public class KeystoneDocumentDbOptions { public string? Map { get; set; } }
+public class KeystoneRelationshipDbOptions { public string? RelationName { get; set; } }
+public class KeystoneRelationshipUiOptions { public bool? HideCreate { get; set; } }
+public class KeystoneFileDbOptions { public string? Map { get; set; } }
+public class KeystoneImageDbOptions { public string? Map { get; set; } }
+public class KeystoneCloudinaryDbOptions { public string? Map { get; set; } }
+public class KeystoneCloudinaryCredentials { public string CloudName { get; set; } = string.Empty; public string ApiKey { get; set; } = string.Empty; public string ApiSecret { get; set; } = string.Empty; public string? Folder { get; set; } }

--- a/Entities/IKeystoneFieldOptions.cs
+++ b/Entities/IKeystoneFieldOptions.cs
@@ -1,6 +1,0 @@
-namespace Keystone4Net.Entities;
-
-public interface IKeystoneFieldOptions
-{
-    
-}

--- a/Entities/KeystoneEntities.cs
+++ b/Entities/KeystoneEntities.cs
@@ -58,18 +58,8 @@ public class KeystoneListUiOptions
 }
 
 
-public class KeystoneTextFieldOptions : IKeystoneFieldOptions
+public class KeystoneTextFieldOptions : KeystoneFieldOptions
 {
-    public object? Access { get; set; }
-
-    public object? Hooks { get; set; }
-
-    public string? Label { get; set; }
-
-    public bool? IsFilterable { get; set; }
-
-    public bool? IsOrderable { get; set; }
-
     public string? DefaultValue { get; set; }
 
     public KeystoneTextDbOptions? Db { get; set; }
@@ -77,10 +67,6 @@ public class KeystoneTextFieldOptions : IKeystoneFieldOptions
     public KeystoneTextValidationOptions? Validation { get; set; }
 
     public KeystoneTextUiOptions? Ui { get; set; }
-
-    public KeystoneIndex? IsIndexed { get; set; }
-
-    public KeystoneFieldGraphqlOptions? Graphql { get; set; }
 }
 
 public class KeystoneFieldUiOptions
@@ -315,12 +301,12 @@ public class KeystoneStoredSession() : KeystoneCookieSession("storedSessions")
     public object? Store { get; set; }
 }
 
-public class KeystoneField(KeystoneFieldType type, IKeystoneFieldOptions? options)
+public class KeystoneField(KeystoneFieldType type, KeystoneFieldOptions? options)
     : KeystoneJsFunctionPropArgCall(KeystoneImportObjects.Fields, Utils.ToCamelCase(type), options)
 {
     public KeystoneFieldType Type { get; set; } = type;
 
-    public IKeystoneFieldOptions? Options { get; set; } = options;
+    public KeystoneFieldOptions? Options { get; set; } = options;
 }
 
 public class KeystoneListAccess(string name) : KeystoneJsObject(KeystoneImportObjects.Access, Utils.ToCamelCase(name))

--- a/Entities/KeystoneFieldAccess.cs
+++ b/Entities/KeystoneFieldAccess.cs
@@ -1,0 +1,9 @@
+namespace Keystone4Net.Entities;
+
+public class KeystoneFieldAccess
+{
+    public KeystoneJsFunction? Read { get; set; }
+    public KeystoneJsFunction? Create { get; set; }
+    public KeystoneJsFunction? Update { get; set; }
+}
+

--- a/Entities/KeystoneFieldOptions.cs
+++ b/Entities/KeystoneFieldOptions.cs
@@ -1,0 +1,16 @@
+using Keystone4Net.Enums;
+
+namespace Keystone4Net.Entities;
+
+public class KeystoneFieldOptions
+{
+    public KeystoneFieldAccess? Access { get; set; }
+    public KeystoneFieldHooks? Hooks { get; set; }
+    public string? Label { get; set; }
+    public bool? IsFilterable { get; set; }
+    public bool? IsOrderable { get; set; }
+    public KeystoneFieldUiOptions? Ui { get; set; }
+    public KeystoneIndex? IsIndexed { get; set; }
+    public KeystoneFieldGraphqlOptions? Graphql { get; set; }
+}
+

--- a/Entities/KeystoneHooks.cs
+++ b/Entities/KeystoneHooks.cs
@@ -1,0 +1,39 @@
+namespace Keystone4Net.Entities;
+
+public class KeystoneListHooks
+{
+    public KeystoneJsFunction? ResolveInput { get; set; }
+    public KeystoneJsFunction? ResolveInputCreate { get; set; }
+    public KeystoneJsFunction? ResolveInputUpdate { get; set; }
+    public KeystoneJsFunction? Validate { get; set; }
+    public KeystoneJsFunction? ValidateCreate { get; set; }
+    public KeystoneJsFunction? ValidateUpdate { get; set; }
+    public KeystoneJsFunction? ValidateDelete { get; set; }
+    public KeystoneJsFunction? BeforeOperation { get; set; }
+    public KeystoneJsFunction? BeforeOperationCreate { get; set; }
+    public KeystoneJsFunction? BeforeOperationUpdate { get; set; }
+    public KeystoneJsFunction? BeforeOperationDelete { get; set; }
+    public KeystoneJsFunction? AfterOperation { get; set; }
+    public KeystoneJsFunction? AfterOperationCreate { get; set; }
+    public KeystoneJsFunction? AfterOperationUpdate { get; set; }
+    public KeystoneJsFunction? AfterOperationDelete { get; set; }
+}
+
+public class KeystoneFieldHooks
+{
+    public KeystoneJsFunction? ResolveInput { get; set; }
+    public KeystoneJsFunction? ResolveInputCreate { get; set; }
+    public KeystoneJsFunction? ResolveInputUpdate { get; set; }
+    public KeystoneJsFunction? Validate { get; set; }
+    public KeystoneJsFunction? ValidateCreate { get; set; }
+    public KeystoneJsFunction? ValidateUpdate { get; set; }
+    public KeystoneJsFunction? ValidateDelete { get; set; }
+    public KeystoneJsFunction? BeforeOperation { get; set; }
+    public KeystoneJsFunction? BeforeOperationCreate { get; set; }
+    public KeystoneJsFunction? BeforeOperationUpdate { get; set; }
+    public KeystoneJsFunction? BeforeOperationDelete { get; set; }
+    public KeystoneJsFunction? AfterOperation { get; set; }
+    public KeystoneJsFunction? AfterOperationCreate { get; set; }
+    public KeystoneJsFunction? AfterOperationUpdate { get; set; }
+    public KeystoneJsFunction? AfterOperationDelete { get; set; }
+}

--- a/Entities/KeystoneList.cs
+++ b/Entities/KeystoneList.cs
@@ -17,7 +17,7 @@ public abstract class KeystoneList(Type type) : KeystoneJsFunctionPropArgCall(Ke
 
     public KeystoneListGraphqlOptions? Graphql { get; set; }
 
-    public object? Hooks { get; set; }
+    public KeystoneListHooks? Hooks { get; set; }
 
     public string? Description { get; set; }
 
@@ -37,7 +37,7 @@ public abstract class KeystoneList(Type type) : KeystoneJsFunctionPropArgCall(Ke
         return key;
     }
 
-    public string Add(string key, KeystoneFieldType value, IKeystoneFieldOptions? options = null)
+    public string Add(string key, KeystoneFieldType value, KeystoneFieldOptions? options = null)
     {
         return this.Add(key, new(value, options));
     }


### PR DESCRIPTION
## Summary
- introduce `KeystoneFieldAccess` and `KeystoneFieldOptions`
- refactor all field option classes to inherit from the base options
- update `KeystoneField` and list helpers to use the new types

## Testing
- `dotnet build --nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c38e42cdc832d8b5655a3080830b4